### PR TITLE
this change makes handshake and x509storeissuer command

### DIFF
--- a/source/handshake.c
+++ b/source/handshake.c
@@ -105,20 +105,6 @@ int main(int argc, char * const argv[])
     }
 
     if (argv[optind] == NULL) {
-        printf("threadcount argument missing\n");
-        goto err;
-    }
-    threadcount = atoi(argv[optind]);
-    if (threadcount < 1) {
-        printf("threadcount must be > 0\n");
-        goto err;
-    }
-    num_calls = NUM_CALLS_PER_TEST;
-    if (NUM_CALLS_PER_TEST % threadcount > 0) /* round up */
-        num_calls += threadcount - NUM_CALLS_PER_TEST % threadcount;
-
-    optind++;
-    if (argv[optind] == NULL) {
         printf("certsdir is missing\n");
         goto err;
     }
@@ -128,10 +114,29 @@ int main(int argc, char * const argv[])
         printf("Failed to allocate cert/privkey\n");
         goto err;
     }
+    optind++;
 
+    if (argv[optind] == NULL) {
+        printf("threadcount argument missing\n");
+        goto err;
+    }
+    threadcount = atoi(argv[optind]);
+    if (threadcount < 1) {
+        printf("threadcount must be > 0\n");
+        goto err;
+    }
     times = OPENSSL_malloc(sizeof(OSSL_TIME) * threadcount);
     if (times == NULL) {
         printf("Failed to create times array\n");
+        goto err;
+    }
+
+    num_calls = NUM_CALLS_PER_TEST;
+    if (NUM_CALLS_PER_TEST % threadcount > 0) /* round up */
+        num_calls += threadcount - NUM_CALLS_PER_TEST % threadcount;
+
+    if (argv[optind] == NULL) {
+        printf("certsdir is missing\n");
         goto err;
     }
 

--- a/source/handshake.c
+++ b/source/handshake.c
@@ -97,7 +97,7 @@ int main(int argc, char * const argv[])
             break;
         default:
             printf(
-                "Usage: %s [-t] [-s] threadcount certsdir\n", basename(argv[0]));
+                "Usage: %s [-t] [-s] certsdir threadcount\n", basename(argv[0]));
             printf("-t - terse output\n");
             printf("-s - disable context sharing\n");
             return EXIT_FAILURE;
@@ -134,11 +134,6 @@ int main(int argc, char * const argv[])
     num_calls = NUM_CALLS_PER_TEST;
     if (NUM_CALLS_PER_TEST % threadcount > 0) /* round up */
         num_calls += threadcount - NUM_CALLS_PER_TEST % threadcount;
-
-    if (argv[optind] == NULL) {
-        printf("certsdir is missing\n");
-        goto err;
-    }
 
     if (share_ctx == 1) {
         if (!perflib_create_ssl_ctx_pair(TLS_server_method(), TLS_client_method(),

--- a/source/x509storeissuer.c
+++ b/source/x509storeissuer.c
@@ -80,7 +80,7 @@ int main(int argc, char *argv[])
             terse = 1;
             break;
         default:
-            printf("Usage: %s [-t] threadcount certsdir\n", basename(argv[0]));
+            printf("Usage: %s [-t] certsdir threadcount\n", basename(argv[0]));
             printf("-t - terse output\n");
             return EXIT_FAILURE;
         }

--- a/source/x509storeissuer.c
+++ b/source/x509storeissuer.c
@@ -87,6 +87,17 @@ int main(int argc, char *argv[])
     }
 
     if (argv[optind] == NULL) {
+        printf("certsdir is missing\n");
+        goto err;
+    }
+    cert = perflib_mk_file_path(argv[optind], "servercert.pem");
+    if (cert == NULL) {
+        printf("Failed to allocate cert\n");
+        goto err;
+    }
+    optind++;
+
+    if (argv[optind] == NULL) {
         printf("threadcount is missing\n");
         goto err;
     }
@@ -98,17 +109,6 @@ int main(int argc, char *argv[])
     num_calls = NUM_CALLS_PER_TEST;
     if (NUM_CALLS_PER_TEST % threadcount > 0) /* round up */
         num_calls += threadcount - NUM_CALLS_PER_TEST % threadcount;
-
-    optind++;
-    if (argv[optind] == NULL) {
-        printf("certsdir is missing\n");
-        goto err;
-    }
-    cert = perflib_mk_file_path(argv[optind], "servercert.pem");
-    if (cert == NULL) {
-        printf("Failed to allocate cert\n");
-        goto err;
-    }
 
     store = X509_STORE_new();
     if (store == NULL || !X509_STORE_set_default_paths(store)) {


### PR DESCRIPTION
line option consistent with other tools.

the consistency here means the thread count is always the last argument.

to run the handshake test one does:
    ./handshake -t path/to/openssl.src/tests/certs 4

Fixes: 10