### PR TITLE
evp_fetch: Make all algorithms run at each test

### DIFF
--- a/source/evp_fetch.c
+++ b/source/evp_fetch.c
@@ -104,6 +104,13 @@ void do_fetch(size_t num)
 
     start = ossl_time_now();
 
+    /*
+     * Going through the fetch entries num_calls / threadcount times.
+     *
+     * Mind a little deviation as the (num_calls / threadcount) does not have
+     * to be a multiple of the number of fetch entries therefore at the last
+     * iteration we may not check all the algorithms.
+     */
     for (i = 0; i < num_calls / threadcount; i++) {
         /*
          * If we set a fetch type, always use that


### PR DESCRIPTION
The evp_fetch looks to not randomly select the algorithms from the list,
but it iterates over the list and runs over it until num_calls / threadcount.

This PR adds the remainder of the (num_calls / threadcount) % ARRAY_SIZE(fetch_entries) to run each algorithm equal times.

Resolves: https://github.com/openssl/project/issues/1207