### PR TITLE
Use OSSL_LIB_CTX pool

### DIFF
--- a/README
+++ b/README
@@ -56,6 +56,8 @@ handshake [-t] [-s] <certsdir> <threadcount>
 -t - produce terse output
 -s - create an ssl_ctx per connection, rather than a single thread-shared ctx
 -p - use ossl_lib_ctx per thread
+-P - use ossl_lib_ctx pool (can be combined with -s. If sharing is enabled, ssl_ctx
+     is shared within single thread)
 certsdir - Directory where the test can locate servercert.pem and serverkey.pem
 threadcount - Number of concurrent threads to run in test
 

--- a/README
+++ b/README
@@ -58,6 +58,7 @@ handshake [-t] [-s] <certsdir> <threadcount>
 -p - use ossl_lib_ctx per thread
 -P - use ossl_lib_ctx pool (can be combined with -s. If sharing is enabled, ssl_ctx
      is shared within single thread)
+-o - set ossl_lib_ctx pool size (use only with -P)
 certsdir - Directory where the test can locate servercert.pem and serverkey.pem
 threadcount - Number of concurrent threads to run in test
 

--- a/source/Makefile
+++ b/source/Makefile
@@ -8,7 +8,7 @@ clean:
 CPPFLAGS += -I$(TARGET_OSSL_INCLUDE_PATH) -I.
 # For second include path, i.e. out of tree build of OpenSSL uncomment this:
 # CPPFLAGS += -I$(TARGET_OSSL_INCLUDE_PATH2)
-CFLAGS += -pthread -O2
+CFLAGS += -pthread -O3
 LDFLAGS += -L$(TARGET_OSSL_LIBRARY_PATH) -L.
 # For setting RUNPATH on built executables uncomment this:
 # LDFLAGS += -Wl,-rpath,$(TARGET_OSSL_LIBRARY_PATH)

--- a/source/Makefile
+++ b/source/Makefile
@@ -8,7 +8,7 @@ clean:
 CPPFLAGS += -I$(TARGET_OSSL_INCLUDE_PATH) -I.
 # For second include path, i.e. out of tree build of OpenSSL uncomment this:
 # CPPFLAGS += -I$(TARGET_OSSL_INCLUDE_PATH2)
-CFLAGS += -pthread
+CFLAGS += -pthread -O2
 LDFLAGS += -L$(TARGET_OSSL_LIBRARY_PATH) -L.
 # For setting RUNPATH on built executables uncomment this:
 # LDFLAGS += -Wl,-rpath,$(TARGET_OSSL_LIBRARY_PATH)


### PR DESCRIPTION
Resolves: https://github.com/openssl/project/issues/1211

@mattcaswell Here are commits that I was talking about this morning. 

Tested against the 52dba1c098d9b0388afa4db2fbe3461df67461c6 openssl branch.

`-s` disables SSL_CTX sharing, which means that each handshake creates its own SSL_CTX.
`-p` uses per thread libctx
`-P` uses a libctx pool of size 16, distributing libctx instances to threads using a simple round-robin approach.

```
| Threads | NoOpts |    -p |   -s | -s -P |    -P | -s -p |
|---------+--------+-------+------+-------+-------+-------|
|       1 |   1736 |  1658 | 1042 |  1022 |  1660 |  1072 |
|      10 |  11994 | 12767 | 6766 |  7408 | 12919 |  7964 |
|      20 |  12304 | 13179 | 5652 |  5621 | 13339 |  5689 |
|      30 |  12123 | 13374 | 5499 |  5151 | 13204 |  5049 |
|      40 |  11667 | 13587 | 5370 |  4898 | 13231 |  5042 |
|      50 |  12209 | 13445 | 5406 |  4855 | 13273 |  5017 |
|      60 |  12311 | 13409 | 5213 |  4857 | 13389 |  4998 |
|      70 |  12072 | 13244 | 5092 |  4721 | 13170 |  4748 |
|      80 |  11961 | 13205 | 5112 |  4640 | 13010 |  4804 |
|      90 |  11897 | 13098 | 5075 |  4477 | 12670 |  4721 |
|     100 |  12074 | 12384 | 4937 |  4458 | 13229 |  4677 |
|     110 |  12200 | 12815 | 4858 |  4571 | 13097 |  4530 |
|     120 |  11838 | 12735 | 4763 |  4501 | 12589 |  4529 |
|     130 |  11079 | 12505 | 4652 |  4548 | 12611 |  4348 |
|     140 |  11314 | 12701 | 4517 |  4324 | 12620 |  4393 |
|     150 |  11245 | 12396 | 4419 |  4425 | 12554 |  4438 |
|     160 |  11048 | 12427 | 4367 |  4296 | 12904 |  4300 |
|     170 |  11139 |       | 4330 |  4357 | 12579 |       |
|     180 |  10399 |       | 4140 |  4228 | 12654 |       |
|     190 |  11275 |       | 4004 |  4183 | 12595 |       |
|     200 |  11297 |       | 4093 |  3644 | 12379 |       |
```
