### PR TITLE
Make our handshake results more intuitive

### DIFF
--- a/source/handshake.c
+++ b/source/handshake.c
@@ -263,7 +263,7 @@ void usage(const char *progname)
 int main(int argc, char * const argv[])
 {
     double persec;
-    OSSL_TIME duration, ttime;
+    OSSL_TIME duration;
     double avcalltime;
     int ret = EXIT_FAILURE;
     int i;
@@ -396,13 +396,14 @@ int main(int argc, char * const argv[])
         goto err;
     }
 
-    ttime = times[0];
-    for (i = 1; i < threadcount; i++)
-        ttime = ossl_time_add(ttime, times[i]);
+    avcalltime = (double)0;
+    persec += (double)0;
+    for (i = 0; i < threadcount; i++) {
+        avcalltime += ((double)ossl_time2ticks(times[i]) / (num_calls / threadcount)) / (double)OSSL_TIME_US;
+        persec += (((num_calls * OSSL_TIME_SECOND) / (double)threadcount) / (double)ossl_time2ticks(times[i]));
+    }
 
-    avcalltime = ((double)ossl_time2ticks(ttime) / num_calls) / (double)OSSL_TIME_US;
-    persec = ((num_calls * OSSL_TIME_SECOND)
-             / (double)ossl_time2ticks(duration));
+    avcalltime /= (double)threadcount;
 
     if (terse) {
         printf("%lf\n", avcalltime);


### PR DESCRIPTION
In doing some testing with the handshake test, I was getting results that made very little sense to me, showing a significant decrease in usecs/handshake, but maintaining consistent handshake/second counts, with the overall time of the test (as measured by time) dropping.

I think what we're currently doing to measure the handshakes per second, while not wrong per se, is a bit counter-intuitive.  We are currently computing this value by summing the time each thread runs and dividing that by the fixed number of handshakes we perform.  While thats sensible, it means that two cpus running in parallel for a total process run time of X seconds produces a cumulative run time of 2X seconds, which, while true, doesn't really accurately reflect the the number of handshakes a multi-threaded process can complete in a given amount of wall clock time.

I'm proposing that we alter the computation so that handshakes per second are computed as:
sum(i=1..N)(handshakes thread[i] completes / time thread[i] exectues) and usecs per handshake be computed as:
sum(i=1..N)(time thread[i] executes / handshakes thread[i] completes)/N