### PR TITLE
Let all threads run for the same amount of time

### DIFF
--- a/source/handshake.c
+++ b/source/handshake.c
@@ -399,8 +399,8 @@ int main(int argc, char * const argv[])
     for (i = 0; i < threadcount; i++)
         total_count += counts[i];
 
-    avcalltime = (double)ossl_time2us(duration) * threadcount / total_count;
-    persec = total_count / (double)ossl_time2seconds(duration);
+    avcalltime = (double)RUN_TIME * 1e6 * threadcount/ total_count;
+    persec = (double)total_count / RUN_TIME;
 
     if (terse) {
         printf("%lf\n", avcalltime);


### PR DESCRIPTION
This is an alternative to #29

The result for me on a 6 core/12 thread system are:

![perf1](https://github.com/user-attachments/assets/ed2ee16e-60a4-4e10-975e-af86e9df56e7)
![perf2](https://github.com/user-attachments/assets/fd3ee0aa-f905-4874-bfb7-f9ef97a4190f)
