### PR TITLE
handshake: enable secure memory alloc

### DIFF
--- a/source/handshake.c
+++ b/source/handshake.c
@@ -376,9 +376,9 @@ int main(int argc, char * const argv[])
             break;
         case 'S': {
             char *end = NULL;
-            errno = 0;
             int sec_mem_size;
 
+            errno = 0;
             sec_mem_size = (int)strtol(optarg, &end, 10);
             if (errno || end == NULL || *end || sec_mem_size <= 0) {
                 fprintf(stderr, "Invalid secure memory size: '%s'\n", optarg);


### PR DESCRIPTION
```
| Threads |    baseline |       secmem |
|---------+-------------+--------------|
|       1 |  586.784756 |   588.306131 |
|       2 |  599.537648 |   601.007393 |
|       4 |  610.663361 |   613.600663 |
|       8 |  649.347376 |   869.693358 |
|      16 | 1176.402781 |  2487.335286 |
|      32 | 2345.594618 |  5155.747515 |
|      64 | 4697.556045 | 11170.627031 |
```

the test shows that sec mem is ok-ish up to the half of number of available cores,
and when the sec mem lock gets contended, performance goes down rapidly.

The test was run on 
Chip: Apple M4 Pro Total
Number of Cores: 12 (8 performance and 4 efficiency)

The test was run on my personal machine, and therefore values can be a bit off because it's a busy machine.

Resolves: https://github.com/openssl/project/issues/1226