### PR TITLE
Allow use of per-thread libctx test to share ssl ctx'es

### DIFF
--- a/source/handshake.c
+++ b/source/handshake.c
@@ -122,14 +122,17 @@ static void do_handshake_ossl_lib_ctx_per_thread(size_t num)
     counts[num] = 0;
 
     do {
-        if (!perflib_create_ossl_lib_ctx_pair(libctx,
-                                              TLS_server_method(),
-                                              TLS_client_method(),
-                                              0, 0, &lsctx, &lcctx, cert,
-                                              privkey)) {
-            fprintf(stderr, "%s:%d: Failed to create SSL_CTX pair\n", __FILE__, __LINE__);
-            err = 1;
-            return;
+
+        if (lsctx == NULL) {
+            if (!perflib_create_ossl_lib_ctx_pair(libctx,
+                                                  TLS_server_method(),
+                                                  TLS_client_method(),
+                                                  0, 0, &lsctx, &lcctx, cert,
+                                                  privkey)) {
+                fprintf(stderr, "%s:%d: Failed to create SSL_CTX pair\n", __FILE__, __LINE__);
+                err = 1;
+                return;
+            }
         }
 
 
@@ -139,9 +142,11 @@ static void do_handshake_ossl_lib_ctx_per_thread(size_t num)
                                              SSL_ERROR_NONE);
         perflib_shutdown_ssl_connection(serverssl, clientssl);
         serverssl = clientssl = NULL;
-        SSL_CTX_free(lsctx);
-        SSL_CTX_free(lcctx);
-        lsctx = lcctx = NULL;
+        if (share_ctx == 0) {
+            SSL_CTX_free(lsctx);
+            SSL_CTX_free(lcctx);
+            lsctx = lcctx = NULL;
+        }
         counts[num]++;
         time = ossl_time_now();
     } while (time.t < max_time.t);


### PR DESCRIPTION
We have the ability to use a per thread libctx object with the -p option, but when we do, we always re-create an ssl-ctx for the client and server, unlike the other modes in which we allow the -s option to re-use ssl-ctxes

We should allow reuse in all test cases to make closer comparisons between test modes (libctx pool, single libctx and libctx-per-thread)

Add recognition of the -s sharing option to the -p per-thread-libctx mode