### PR TITLE
Additional information about test run

### DIFF
--- a/source/Makefile
+++ b/source/Makefile
@@ -49,7 +49,7 @@ regen_key_samples:
 	./genkeys_setpeer.sh > keys_setpeer.h
 
 pkeyread: pkeyread.c keys.h libperf.a
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o pkeyread pkeyread.c -lperf -lcrypto
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o pkeyread pkeyread.c -lperf -lcrypto -lm
 
 evp_setpeer: evp_setpeer.c libperf.a
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o evp_setpeer evp_setpeer.c -lperf -lcrypto

--- a/source/pkeyread.c
+++ b/source/pkeyread.c
@@ -46,6 +46,9 @@ static void do_pemread(size_t num)
     BIO *pem;
     size_t i;
     OSSL_TIME time;
+    size_t count = 0;
+
+    counts[num] = 0;
 
     if (sample_id >= SAMPLE_ALL) {
         fprintf(stderr, "%s no sample key set for test\n", __func__);
@@ -64,8 +67,6 @@ static void do_pemread(size_t num)
         return;
     }
 
-    counts[num] = 0;
-
     /*
      * Technically this includes the EVP_PKEY_free() in the timing - but I
      * think we can live with that
@@ -77,16 +78,17 @@ static void do_pemread(size_t num)
                     (unsigned long long)i,
                     sample_names[sample_id]);
             err = 1;
-            BIO_free(pem);
-            return;
+            goto end;
         }
         EVP_PKEY_free(key);
         BIO_reset(pem);
 
-        counts[num]++;
+        count++;
         time = ossl_time_now();
     } while (time.t < max_time.t);
 
+end:
+    counts[num] = count;
     BIO_free(pem);
 }
 

--- a/source/pkeyread.c
+++ b/source/pkeyread.c
@@ -297,7 +297,6 @@ int main(int argc, char * const argv[])
         usage(argv);
         return EXIT_FAILURE;
     }
-    max_time = ossl_time_add(ossl_time_now(), ossl_seconds2time(RUN_TIME));
 
     counts = OPENSSL_malloc(sizeof(size_t) * threadcount);
     if (counts == NULL) {
@@ -323,6 +322,7 @@ int main(int argc, char * const argv[])
     for (k = key_id_min; k < key_id_max; k++) {
         for (f = format_id_min; f < format_id_max; f++) {
             sample_id = k;
+            max_time = ossl_time_add(ossl_time_now(), ossl_seconds2time(RUN_TIME));
             if (!perflib_run_multi_thread_test(do_f[f], threadcount, &duration)) {
                 fprintf(stderr, "Failed to run the test %s in %s format]\n",
                         sample_names[k], format_names[f]);


### PR DESCRIPTION
This is a proposal about adding additional information in the test run outputs.

At some point, I decided to look at possible thread starvation, so augmented some of the test output with the relevant calculation;  when was reviewing #36 later, decided to formalise the patch, at least for `pkeyread`, as it my changes applied cleanly already.

So far, haven't seen anything interesting;  the only consistent discrepancy I got on low thread counts was a result of heterogenousness of the system I was running my trials on;  might be useful for running on systems with larger core counts, however.

Supposed to be applied on top of #36.

Example output:
```
esyr@bsgalactica:~/dev/perftools/source$ ./pkeyread -k all -f all -T 1.5 -v 12
pem(dh):      avg:  1400.342 us, median:  1535.312 us, min:  1182.033 us @thread   0, max:  1540.041 us @thread   4, stddev:   165.340 us ( 11.8071%)
der(dh):      avg:  1381.215 us, median:  1515.152 us, min:  1168.224 us @thread   9, max:  1522.843 us @thread   6, stddev:   150.592 us ( 10.9028%)
pem(dhx):     avg:   287.715 us, median:   314.531 us, min:   244.379 us @thread   7, max:   316.723 us @thread   1, stddev:    33.350 us ( 11.5912%)
der(dhx):     avg:   271.285 us, median:   297.855 us, min:   228.659 us @thread   9, max:   299.103 us @thread  10, stddev:    32.667 us ( 12.0414%)
pem(dsa):     avg:   295.048 us, median:   324.675 us, min:   248.963 us @thread   9, max:   325.098 us @thread  10, stddev:    33.536 us ( 11.3664%)
der(dsa):     avg:   296.912 us, median:   327.797 us, min:   249.335 us @thread   8, max:   328.731 us @thread   2, stddev:    37.350 us ( 12.5796%)
pem(ec):      avg:    43.173 us, median:    46.325 us, min:    37.665 us @thread   9, max:    46.733 us @thread  10, stddev:     4.020 us (  9.3110%)
der(ec):      avg:    27.616 us, median:    28.359 us, min:    25.233 us @thread   9, max:    31.358 us @thread   2, stddev:     1.857 us (  6.7248%)
pem(rsa):     avg:    38.969 us, median:    41.290 us, min:    34.812 us @thread   5, max:    41.455 us @thread   0, stddev:     3.003 us (  7.7056%)
der(rsa):     avg:    18.523 us, median:    18.502 us, min:    17.478 us @thread   0, max:    21.137 us @thread   1, stddev:     0.967 us (  5.2196%)
pem(x25519):  avg:    50.363 us, median:    53.825 us, min:    44.207 us @thread  11, max:    54.448 us @thread   3, stddev:     4.463 us (  8.8612%)
der(x25519):  avg:    33.535 us, median:    37.169 us, min:    27.766 us @thread  11, max:    37.616 us @thread  10, stddev:     4.464 us ( 13.3113%)
```

Thread numbers are also useless here as long as thread pinning is not implemented in the perf lib.