### PR TITLE
fix broken link on Debian 11

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -160,7 +160,7 @@ add_executable(rwlocks rwlocks.c)
 target_link_libraries(rwlocks PRIVATE perf)
 
 add_executable(pkeyread pkeyread.c)
-target_link_libraries(pkeyread PRIVATE perf)
+target_link_libraries(pkeyread PUBLIC m PRIVATE perf)
 
 add_executable(evp_setpeer evp_setpeer.c)
 target_link_libraries(evp_setpeer PRIVATE perf)


### PR DESCRIPTION
Debian 11 complains about missing sqrt symbol when
building pkeyread. Adding '-lm' makes Debian 11 happy.