### PR TITLE
it's better to include opensslv.h if one checks openssl version

### DIFF
--- a/source/newrawkey.c
+++ b/source/newrawkey.c
@@ -18,6 +18,7 @@
 # include "perflib/getopt.h"
 # include "perflib/basename.h"
 #endif	/* _WIN32 */
+#include <openssl/opensslv.h>
 #include <openssl/evp.h>
 #include "perflib/perflib.h"
 


### PR DESCRIPTION
Fixes #44 