### PR TITLE
update documentation in CMakeList.txt

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -99,7 +99,7 @@
 # ========================
 # According to cmake changelog [1] you may need to add -DCMAKE_OSX_SYSROOT=macosx
 # option to prevent cmake to search for header files in /usr/local/include.
-# You typically needs it if openssl library you want to test is installed
+# You typically need it if openssl library you want to test is installed
 # in non-standard location (for example in ~/openssl.binaries. In that
 # case you want to build tools using commands:
 #	cmake -S . -B build -DOPENSSL_ROOT_DIR=~/openssl.binaries \


### PR DESCRIPTION
cmake 4.x requires a `-DCMAKE_OSX_SYSROOT=macosx` so it can pick header files from locations we expect.

in general we avoid including openssl from usr/local/include because we build/install openssl library to test
to non-standard location. we don't want cmake to accidentally discover openssl library installed in /usr/local/include.

Fixes: #44