### PR TITLE
perflib, handshake: do not use OSSL_LIB_CTX on OpenSSL < 3.0

### DIFF
--- a/source/perflib/perflib.h
+++ b/source/perflib/perflib.h
@@ -48,10 +48,12 @@ int perflib_create_ssl_ctx_pair(const SSL_METHOD *sm, const SSL_METHOD *cm,
                                 int min_proto_version, int max_proto_version,
                                 SSL_CTX **sctx, SSL_CTX **cctx, char *certfile,
                                 char *privkeyfile);
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
 int perflib_create_ossl_lib_ctx_pair(OSSL_LIB_CTX *libctx, const SSL_METHOD *sm,
                                      const SSL_METHOD *cm, int min_proto_version,
                                      int max_proto_version, SSL_CTX **sctx, SSL_CTX **cctx,
                                      char *certfile, char *privkeyfile);
+#endif /* OPENSSL_VERSION_NUMBER >= 0x30000000L */
 int perflib_create_ssl_objects(SSL_CTX *serverctx, SSL_CTX *clientctx,
                                SSL **sssl, SSL **cssl, BIO *s_to_c_fbio,
                                BIO *c_to_s_fbio);

--- a/source/perflib/perfsslhelper.c
+++ b/source/perflib/perfsslhelper.c
@@ -61,6 +61,7 @@ static int perflib_use_certificate(SSL_CTX *serverctx, SSL_CTX *clientctx,
     return 0;
 }
 
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
 int perflib_create_ossl_lib_ctx_pair(OSSL_LIB_CTX *libctx, const SSL_METHOD *sm,
                                      const SSL_METHOD *cm, int min_proto_version,
                                      int max_proto_version, SSL_CTX **sctx, SSL_CTX **cctx,
@@ -90,6 +91,7 @@ int perflib_create_ossl_lib_ctx_pair(OSSL_LIB_CTX *libctx, const SSL_METHOD *sm,
  err:
     return 0;
 }
+#endif /* OPENSSL_VERSION_NUMBER >= 0x30000000L */
 
 int perflib_create_ssl_ctx_pair(const SSL_METHOD *sm,
                                 const SSL_METHOD *cm, int min_proto_version,


### PR DESCRIPTION
OSSL_LIB_CTX object and related APIs have been introduced in OpenSSL 3.0, and its usage prevents compiling perftools with OpenSSL 1.1.1. So far, it is limited to specific handshake testing modes, so just put the relevant code into conditional preprocessor sections.

Resolves: https://github.com/openssl/perftools/issues/54