### PR TITLE
Properly initalize counts array

### DIFF
--- a/source/writeread.c
+++ b/source/writeread.c
@@ -169,7 +169,7 @@ int main(int argc, char * const argv[])
         goto err;
     }
 
-    counts = OPENSSL_malloc(sizeof(size_t) * threadcount);
+    counts = OPENSSL_zalloc(sizeof(size_t) * threadcount);
     if (counts == NULL) {
         fprintf(stderr, "Failed to create counts array\n");
         goto err;


### PR DESCRIPTION
The writeread test was producing wildly inconsistent results on windows.

Problem turned out to be the allocation of the counts array, which by some stroke of luck seems to always get a buffer full of zeros on most platforms...except for windows which more frequently gets whatever garbage is on the heap at the allocated location.  This in turn leads to count values that start at some huge number and goes up from there, leading to 0 average per call run time results.

Allocate the array with zalloc to ensure 0 count values at the start of the test.

Fixes #56