### PR TITLE
evp_setpeer: fix -k all

### DIFF
--- a/source/evp_setpeer.c
+++ b/source/evp_setpeer.c
@@ -182,8 +182,6 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
-    max_time = ossl_time_add(ossl_time_now(), ossl_seconds2time(RUN_TIME));
-
     counts = OPENSSL_malloc(sizeof(OSSL_TIME) * threadcount);
     if (counts == NULL) {
         printf("Failed to create counts array\n");
@@ -221,6 +219,8 @@ int main(int argc, char *argv[])
                     sample_names[k]);
             return EXIT_FAILURE;
         }
+
+        max_time = ossl_time_add(ossl_time_now(), ossl_seconds2time(RUN_TIME));
 
         if (!perflib_run_multi_thread_test(do_setpeer, threadcount, &duration)) {
             fprintf(stderr, "Failed to run the test %s\n", sample_names[k]);


### PR DESCRIPTION
As max_time was initialised only once, the runs after the first one terminated immediately.  Move max_time inside the key type loop.

Fixes: 7388d621bbf8 "Set a constant amount of runtime on more perf tests"