### PR TITLE
.github/workflows/test.yml: limit openssl building parallelism

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
     - name: "Build openssl"
       working-directory: "./openssl"
       run: |
-        make -j
+        make -j 4
     - name: "Install openssl"
       working-directory: "./openssl"
       run: |
@@ -169,7 +169,7 @@ jobs:
     - name: "Build openssl"
       working-directory: "./openssl"
       run: |
-        make -j
+        make -j 4
     - name: "Install openssl"
       working-directory: "./openssl"
       run: |
@@ -508,7 +508,7 @@ jobs:
     - name: "Build openssl"
       working-directory: "./openssl"
       run: |
-        make -j
+        make -j 4
     - name: "Install openssl"
       working-directory: "./openssl"
       run: |


### PR DESCRIPTION
"make -j" leads to unlimited concurrency during execution of the openssl build step, which sometimes leads to failures due to resource exhaustion. Try to avoid that by limiting the number of concurrently executed jobs to 4, similarly to the way it is done elsewhere in the workflow steps (including building openssl on FreeBSD).