### PR TITLE
Add evp_pkey perftool

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,24 +331,25 @@ thread-count - number of thread
 ./evp_rand -o evp_shared 10
 ```
 
-## evp_signature
+## evp_pkey
 
-This CLI tool signs data using RSA and a SHA256 digest as input.
-Runs for 5 seconds and prints the average execution time per computation.
+This CLI tool that generates keys using a given algorithm.
+Runs for 5 seconds and prints the average execution time per key generation.
 
 Two modes of operation:
 - evp_shared (default): Use EVP API and allow shared data between computations
 - evp_isolated: Use EVP API and don't allow shared data between computations
 
 ```
-Usage: evp_signature [-h] [-t] [-o operation] [-V] thread-count
+Usage: evp_pkey [-h] [-t] [-o operation] [-V] thread-count
 -h - print this help output
 -t - terse output
 -o operation - mode of operation. One of [evp_isolated, evp_shared] (default: evp_shared)
+-a algorithm - algorithm for generated key. One of [RSA, X25519, X448, ED25519, ED448] (default: ED25519)
 -V - print version information and exit
 thread-count - number of threads
 ```
 
 ```sh
-./evp_signature -o evp_shared 10
+./evp_pkey -o evp_shared -a RSA 10
 ```

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -226,8 +226,8 @@ target_link_libraries(evp_kdf PRIVATE perf)
 add_executable(evp_rand evp_rand.c)
 target_link_libraries(evp_rand PRIVATE perf)
 
-add_executable(evp_signature evp_signature.c)
-target_link_libraries(evp_signature PRIVATE perf)
+add_executable(evp_pkey evp_pkey.c)
+target_link_libraries(evp_pkey PRIVATE perf)
 
 ## Running tests
 # Options
@@ -237,7 +237,7 @@ set(run_tests evp_fetch
               evp_mac
               evp_kdf
               evp_rand
-              evp_signature
+              evp_pkey
               evp_setpeer
               handshake
               newrawkey
@@ -287,9 +287,12 @@ set(run_evp_kdf_operations
 set(run_evp_rand_operations
     evp_rand "" "" "-o evp_isolated" "-o evp_shared"
     CACHE STRING "Modes of operation for evp_rand")
-set(run_evp_signature_operations
-    evp_signature "" "" "-o evp_isolated" "-o evp_shared"
-    CACHE STRING "Modes of operation for evp_signature")
+set(run_evp_pkey_operations
+    evp_pkey "" "" "-o evp_isolated" "-o evp_shared"
+    CACHE STRING "Modes of operation for evp_pkey")
+set(run_evp_pkey_algorithms
+    evp_pkey "" "" "-a RSA" "-a X25519" "-a X448" "-a ED25519" "-a ED448"
+    CACHE STRING "Algorithms for evp_pkey")
 set(run_evp_setpeer_keys
     evp_setpeer "-k" dh ec256 ec521 x25519 all
     CACHE STRING "Key types for evp_setpeer")
@@ -334,7 +337,8 @@ set(run_opts run_evp_fetch_pqs
              run_evp_mac_operations
              run_evp_kdf_operations
              run_evp_rand_operations
-             run_evp_signature_operations
+             run_evp_pkey_operations
+             run_evp_pkey_algorithms
              run_evp_setpeer_keys
              run_newrawkey_algos
              run_pkeyread_keys


### PR DESCRIPTION
## Summary

This CLI tool that generates keys using a given algorithm.
Runs for 5 seconds and prints the average execution time per key generation.

Fixes https://github.com/openssl/project/issues/1877

## Features

- Two modes of operation:
  - `evp_shared` (default): Use EVP API and allow shared data between computations
  - `evp_isolated`: Use EVP API and don't allow shared data between computations
- Configurable number of times to update
- Terse output for easier CI automation (`-t`)
- Configurable thread count

## Usage

```console
$ ./evp_pkey -h
Usage: evp_pkey [-h] [-t] [-o operation] [-a algorithm] [-V] thread-count
-h - print this help output
-t - terse output
-o operation - mode of operation. One of [evp_isolated, evp_shared] (default: evp_shared)
-a algorithm - algorithm for generated key. One of [RSA, X25519, X448, ED25519, ED448] (default: ED25519)
-V - print version information and exit
thread-count - number of threads

$ ./evp_rand -o evp_shared 10 # evp_shared operation mode, ED25519 algorithm, 10 threads
Average time per key generation: 36.481838us

$ ./evp_rand -o evp_isolated 10 # now using evp_isolated mode
Average time per key generation: 34.623617us
```