### PR TITLE
evp_kdf: add freeze option

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,9 +329,10 @@ Four modes of operation:
 - deprecated_isolated: Use legacy API and don't allow shared data between computations
 
 ```
-Usage: evp_kdf [-h] [-t] [-o operation] [-V] thread-count
+Usage: evp_kdf [-h] [-t] [-f] [-o operation] [-V] thread-count
 -h - print this help output
 -t - terse output
+-f - freeze default context (available only with openssl >= 4.x.x)
 -o operation - mode of operation. One of [evp_isolated, evp_shared, deprecated_isolated, deprecated_shared] (default: evp_shared)
 -V - print version information and exit
 thread-count - number of threads

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -346,6 +346,12 @@ list(APPEND run_opts run_writeread_buffers)
 add_executable(evp_hash evp_hash.c)
 target_link_libraries(evp_hash PRIVATE perf)
 list(APPEND run_tests evp_hash)
+if( HAVE_OSSL_LIB_CTX_FREEZE )
+    set(run_evp_kdf_freeze
+        evp_kdf "" "" "-f"
+        CACHE STRING "Freeze LIB_CTX for evp_kdf")
+    list(APPEND run_opts run_evp_kdf_freeze)
+endif()
 set(run_evp_hash_operations
     evp_hash "" "" "-o deprecated" "-o evp_isolated" "-o evp_shared"
     CACHE STRING "Modes of operation for evp_hash")


### PR DESCRIPTION
  $ ./evp_kdf -o evp_isolated 64 -f
  Average time per computation: 8181.213888us
  $ ./evp_kdf -o evp_isolated 64
  Average time per computation: 8307.157135us