### PR TITLE
evp_rand: add freeze option

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,12 +320,13 @@ Two modes of operation:
 - evp_isolated: Use EVP API and don't allow shared data between computations
 
 ```
-Usage: evp_rand [-h] [-t] [-o operation] [-V] thread-count
+Usage: evp_rand [-h] [-t] [-f] [-o operation] [-V] thread-count
 -h - print this help output
 -t - terse output
+-f - freeze default context
 -o operation - mode of operation. One of [evp_isolated, evp_shared] (default: evp_shared)
 -V - print version information and exit
-thread-count - number of thread
+thread-count - number of threads
 ```
 
 ```sh

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -298,6 +298,9 @@ set(run_evp_pkey_operations
 set(run_evp_pkey_algorithms
     evp_pkey "" "" "-a RSA" "-a X25519" "-a X448" "-a ED25519" "-a ED448"
     CACHE STRING "Algorithms for evp_pkey")
+set(run_evp_rand_freeze
+    evp_rand "" "" "-f"
+    CACHE STRING "Freeze LIB_CTX for evp_rand")
 set(run_evp_setpeer_keys
     evp_setpeer "-k" dh ec256 ec521 x25519 all
     CACHE STRING "Key types for evp_setpeer")
@@ -359,7 +362,8 @@ set(run_opts run_evp_fetch_pqs
 
 if(HAVE_OSSL_LIB_CTX_FREEZE)
   list(APPEND run_opts run_evp_hash_freeze
-                       run_evp_cipher_freeze)
+                       run_evp_cipher_freeze
+                       run_evp_rand_freeze)
 endif()
 
 # Used across multiple tests


### PR DESCRIPTION
Adds `-f` option to `evp_rand` perftool to freeze OSSL_LIB_CTX

```console
$ ./evp_rand -o evp_shared 10
Average time per computation: 3.014978us
$ ./evp_rand -o evp_shared -f 10
Average time per computation: 1.696625us
$ ./evp_rand -o evp_isolated 10
Average time per computation: 18.306670us
$ ./evp_rand -o evp_isolated -f 10
Average time per computation: 13.355264us
```

Speeds up `evp_rand_fetch`, even for `evp_shared` case

Fixes https://github.com/openssl/project/issues/1881