### PR TITLE
just small clean-up to use better names for functions

### DIFF
--- a/bench-scripts/bench_config_haproxy.sh
+++ b/bench-scripts/bench_config_haproxy.sh
@@ -114,9 +114,14 @@ function install_haproxy {
         cd "${WORKSPACE_ROOT}" || exit 1
         mkdir -p "${DIRNAME}" || exit 1
         cd "${DIRNAME}"
-        git clone "${HAPROXY_REPO}" -b ${VERSION} --depth 1 . || exit 1
-        
-        # haproxy does not have a configure script; only a big makefile
+        git clone -b ${VERSION} --depth 1 "${HAPROXY_REPO}" . || exit 1
+
+        #
+        # haproxy does not have a configure script; only makefile
+        # also note gnu-make is assumed here for ha-proxy build,
+        # you may need to adjust the script when on non-gnu
+        # platform.
+        #
         make clean
         make ${MAKE_OPTS} \
              TARGET=${HAPROXY_BUILD_TARG} \
@@ -367,76 +372,38 @@ function config_haproxy {
 }
 
 function setup_tests {
-    typeset i=0
-    cd "${WORKSPACE_ROOT}"
-    install_openssl master
-    install_haproxy openssl-master
-    install_httpterm openssl-master
-    install_h1load openssl-master
-    install_siege openssl-master
-    config_haproxy openssl-master
-    clean_build
+    typeset SSL_LIB=""
 
-    for i in 3.0 3.1 3.2 3.3 3.4 3.5 3.6 ; do
-        cd "${WORKSPACE_ROOT}"
-        install_openssl openssl-$i
-        install_haproxy openssl-$i
-        install_httpterm openssl-$i
-        install_h1load openssl-$i
-        install_siege openssl-$i
-        config_haproxy openssl-$i
-        clean_build
+    cd "${WORKSPACE_ROOT}"
+
+    for SSL_LIB in `ssl_libs_haproxy` ;  do
+         case ${SSL_LIB} in
+             openssl*)
+                 install_openssl ${SSL_LIB}
+                 ;;
+             OpenSSL_*)
+                 install_openssl ${SSL_LIB}
+                 ;;
+             wolfssl*)
+                 install_wolfssl ${HAPROXY_WOLF_VERSION} '--enable-haproxy --enable-quic'
+                 ;;
+             libressl*)
+                 install_libressl ${HAPROXY_LIBRE_VERSION}
+                 ;;
+             aws-lc*)
+                 install_aws_lc
+                 ;;
+         esac
+         if [[ ${SSL_LIB} = 'openssl-master' ]] ; then
+             install_siege ${SSL_LIB}
+         fi
+
+         install_haproxy ${SSL_LIB}
+         install_httpterm ${SSL_LIB}
+         install_h1load ${SSL_LIB}
+         config_haproxy ${SSL_LIB}
+         clean_build ${SSL_LIB}
     done
-
-    cd "${WORKSPACE_ROOT}"
-    install_openssl OpenSSL_1_1_1-stable
-    install_haproxy OpenSSL_1_1_1-stable
-    install_httpterm OpenSSL_1_1_1-stable
-    install_h1load OpenSSL_1_1_1-stable
-    install_siege OpenSSL_1_1_1-stable
-    config_haproxy OpenSSL_1_1_1-stable
-    clean_build
-
-    cd "${WORKSPACE_ROOT}"
-    install_wolfssl ${HAPROXY_WOLF_VERSION} '--enable-haproxy --enable-quic'
-    install_haproxy wolfssl-${HAPROXY_WOLF_VERSION}
-    install_httpterm wolfssl-${HAPROXY_WOLF_VERSION}
-    install_h1load wolfssl-${HAPROXY_WOLF_VERSION}
-    install_siege wolfssl-${HAPROXY_WOLF_VERSION}
-    config_haproxy wolfssl-${HAPROXY_WOLF_VERSION}
-    clean_build
-
-    cd "${WORKSPACE_ROOT}"
-    install_libressl ${HAPROXY_LIBRE_VERSION}
-    install_haproxy libressl-${HAPROXY_LIBRE_VERSION}
-    install_httpterm libressl-${HAPROXY_LIBRE_VERSION}
-    install_h1load libressl-${HAPROXY_LIBRE_VERSION}
-    install_siege libressl-${HAPROXY_LIBRE_VERSION}
-    config_haproxy libressl-${HAPROXY_LIBRE_VERSION}
-    clean_build
-
-    #
-    # does not build with boring
-    #
-    #install_boringssl
-    #install_haproxy boringssl
-    #install_httpterm boringssl
-    #install_h1load boringssl
-    #config_haproxy boringssl
-    #cd "${WORKSPACE_ROOT}"
-    #clean_build
-
-    cd "${WORKSPACE_ROOT}"
-    install_aws_lc
-    install_haproxy aws-lc
-    install_httpterm aws-lc
-    install_h1load aws-lc
-    #
-    # siege does not build for aws-lc due to missing CRYPTO_thread_id()
-    #
-    #install_siege aws-lc
-    config_haproxy aws-lc
-    clean_build aws-lc
 }
 
 check_env

--- a/bench-scripts/bench_run_haproxy.sh
+++ b/bench-scripts/bench_run_haproxy.sh
@@ -167,20 +167,13 @@ function run_test {
 }
 
 function run_tests {
-    typeset i=''
-    typeset t=''
+    typeset SSL_LIB=''
+    typeset THREAD_COUNT=''
 
-    for t in 1 2 4 8 16 32 64 ; do
-        for i in 3.0 3.1 3.2 3.3 3.4 3.5 3.6 master ; do
-            run_test openssl-${i} ${t}
+    for THREAD_COUNT in `thread_counts` ; do
+        for SSL_LIB in `ssl_libs_haproxy` ; do
+            run_test ${SSL_LIB} ${THREAD_COUNT}
         done
-        run_test OpenSSL_1_1_1-stable ${t}
-        run_test libressl-${HAPROXY_LIBRE_VERSION} ${t}
-        run_test wolfssl-${HAPROXY_WOLF_VERSION} ${t}
-        run_test aws-lc ${t}
-        #
-        # could not get haproxy working with boringssl
-        #
     done
 }
 
@@ -300,12 +293,12 @@ EOF
 # by 2 ha-proxy configurations used for testing)
 # The columns in merged file holds benchmark results for
 # particular library (ssl_libs_haproxy), while rows hold
-# the result for number of procs
+# the result for number of threads
 #
 function merge_siege {
     typeset RESULT_DIR=${1:-'.'}
     typeset HANDSHAKE=''
-    typeset PROCS=''
+    typeset THREAD_COUNT=''
     typeset SSL_LIB=''
     typeset ROW=''
     typeset VALUE=''
@@ -334,14 +327,14 @@ function merge_siege {
             done
             printf '\n' >> ${OUTPUT_FILE}
             LINE=1
-            for PROCS in `procs` ; do
+            for THREAD_COUNT in `thread_counts` ; do
                 #
                 # row header with number CPUs used for test
                 #
-                printf "${LINE}\t${PROCS}" >> ${OUTPUT_FILE}
+                printf "${LINE}\t${THREAD_COUNT}" >> ${OUTPUT_FILE}
                 LINE=$(( ${LINE} + 1))
                 for SSL_LIB in `ssl_libs_haproxy` ; do
-                    INPUT_FILE=${HANDSHAKE}-${PROCS}-${SSL_LIB}.out
+                    INPUT_FILE=${HANDSHAKE}-${THREAD_COUNT}-${SSL_LIB}.out
                     INPUT_FILE=${RESULT_DIR}/${INPUT_FILE}
                     if [[ -f ${INPUT_FILE} ]] ; then
                         #
@@ -400,7 +393,7 @@ function merge_siege {
 function merge_h1load {
     typeset RESULT_DIR=${1:-'.'}
     typeset HANDSHAKE=''
-    typeset PROCS=''
+    typeset THREAD_COUNT=''
     typeset SSL_LIB=''
     typeset DURATION=''
     typeset INPUT_FILE=''
@@ -413,10 +406,10 @@ function merge_h1load {
             printf "\t${SSL_LIB}" >> ${OUTPUT_FILE}
         done
         printf "\n" >> ${OUTPUT_FILE}
-        for PROCS in `procs` ; do
-            printf "${PROCS}" >> ${OUTPUT_FILE}
+        for THREAD_COUNT in `thread_counts` ; do
+            printf "${THREAD_COUNT}" >> ${OUTPUT_FILE}
             for SSL_LIB in `ssl_libs_haproxy` ; do
-                INPUT_FILE=${RESULT_DIR}/${HANDSHAKE}-${PROCS}-${SSL_LIB}.out
+                INPUT_FILE=${RESULT_DIR}/${HANDSHAKE}-${THREAD_COUNT}-${SSL_LIB}.out
                 #
                 # h1load outputs performance data combined with percentile table. Those
                 # parts are delimited by ^#= delimiter. The sed expression chops off
@@ -427,7 +420,7 @@ function merge_h1load {
                 #
                 DURATION=$(sed -ne '/^#=/q;p' "${INPUT_FILE}" |tail -1 |awk '{ printf($1); }')
                 printf "\t${DURATION}" >> ${OUTPUT_FILE}
-            one
+            done
             #
             # new line
             #

--- a/bench-scripts/common_util.sh
+++ b/bench-scripts/common_util.sh
@@ -109,6 +109,9 @@ function install_openssl {
 
 	if [[ "${BRANCH_NAME}" = 'master' ]] ; then
 		DIRNAME='openssl-master'
+	elif [[ "${BRANCH_NAME}" = 'openssl-master' ]] ; then
+		DIRNAME='openssl-master'
+		BRANCH_NAME='master'
 	else
 		DIRNAME="${BRANCH_NAME}"
 	fi
@@ -402,6 +405,12 @@ function gen_certkey_ec {
 HAPROXY_LIBRE_VERSION='4.2.1'
 HAPROXY_WOLF_VERSION='5.8.4'
 function ssl_libs_haproxy {
+	typeset i=''
+
+	#
+	# NOTE: always build openssl-master,because test
+	# uses openssl(1) tool from master to generate certificates.
+	#
 	echo -n 'openssl-master'
 	for i in 3.0 3.1 3.2 3.3 3.4 3.5 3.6 ; do
 		echo -n " openssl-$i"
@@ -410,6 +419,9 @@ function ssl_libs_haproxy {
 	echo -n " libressl-${HAPROXY_LIBRE_VERSION}"
 	echo -n " wolfssl-${HAPROXY_WOLF_VERSION}"
 	echo ' aws-lc'
+	#
+	# could not get ha-proxy working with boringssl
+	#
 }
 
 #
@@ -436,7 +448,7 @@ function siege_rows {
 # number of processes we perform the test runs
 # thou output reads as follows:
 #	1 2 4 8 16 32 64
-function procs {
+function thread_counts {
 	echo -n '1 '
 	echo -n '2 '
 	echo -n '4 '


### PR DESCRIPTION
and veriables. Adding few comments to clarify code.

also let setup_tests() function to use ssl_libs_haproxy list of libraries to test. The list is defined in common_util.sh and used by bench_run_haproxy.sh script. The common list helps to maintain conistency.