### PR TITLE
handshake: free libctx after the SSL_CTXs to fix use-after-free

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -411,13 +411,13 @@ jobs:
       working-directory: ".\\openssl"
       shell: cmd
       run: |
-        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
         perl Configure no-makedepend ${{ matrix.release.configopts }}
     - name: "Build openssl"
       working-directory: ".\\openssl"
       shell: cmd
       run: |
-        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
         nmake
     - name: "Checkout perftools"
       uses: "actions/checkout@v5"

--- a/source/handshake.c
+++ b/source/handshake.c
@@ -246,9 +246,9 @@ static void free_ctx_pool()
         return;
     for (int i = 0; i < pool_size; ++i) {
         if (ctx_pool[i]) {
-            OSSL_LIB_CTX_free(ctx_pool[i]->libctx);
             SSL_CTX_free(ctx_pool[i]->sctx);
             SSL_CTX_free(ctx_pool[i]->cctx);
+            OSSL_LIB_CTX_free(ctx_pool[i]->libctx);
             OPENSSL_free(ctx_pool[i]);
         }
     }


### PR DESCRIPTION
The SSL_CTX objects (sctx and cctx) are created from the per-pool OSSL_LIB_CTX and hold references back into it. Freeing the library context first left SSL_CTX_free() operating on a freed libctx.

Reorder free_ctx_pool() so the SSL_CTXs are torn down first and the OSSL_LIB_CTX is freed last, matching their creation dependency.

Assisted-by: Claude:claude-sonnet-4-6