### PR TITLE
 Avoid false sharing: accumulate iteration counts locally, store once at the end

### DIFF
--- a/source/evp_cipher.c
+++ b/source/evp_cipher.c
@@ -83,6 +83,7 @@ err:
 static void do_cipher_isolated(size_t num)
 {
     OSSL_TIME time;
+    size_t count = 0;
 
     do {
         if (!cipher_isolated()) {
@@ -90,15 +91,18 @@ static void do_cipher_isolated(size_t num)
             return;
         }
 
-        counts[num]++;
+        count++;
         time = ossl_time_now();
     } while (time.t < max_time.t);
+
+    counts[num] = count;
 }
 
 static void do_cipher_shared(size_t num)
 {
     OSSL_TIME time;
     EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+    size_t count = 0;
 
     if (ctx == NULL || !EVP_CipherInit_ex2(ctx, evp_cipher, key, iv, 1, NULL)) {
         err = 1;
@@ -111,11 +115,12 @@ static void do_cipher_shared(size_t num)
             goto err;
         }
 
-        counts[num]++;
+        count++;
         time = ossl_time_now();
     } while (time.t < max_time.t);
 
 err:
+    counts[num] = count;
     EVP_CIPHER_CTX_free(ctx);
 }
 

--- a/source/evp_fetch.c
+++ b/source/evp_fetch.c
@@ -163,6 +163,7 @@ void do_fetch(size_t num)
 {
     OSSL_TIME time;
     size_t i, j;
+    size_t count = 0;
     const char *fetch_alg = NULL;
     int array_size = ARRAY_SIZE(fetch_entries);
 
@@ -282,9 +283,11 @@ void do_fetch(size_t num)
             err = 1;
             return;
         }
-        counts[num]++;
+        count++;
         time = ossl_time_now();
     } while (time.t < max_time.t);
+
+    counts[num] = count;
 }
 
 static void

--- a/source/evp_hash.c
+++ b/source/evp_hash.c
@@ -191,6 +191,7 @@ static int hash_evp_sha512()
 static void do_hash_isolated(size_t num)
 {
     OSSL_TIME time;
+    size_t count = 0;
 
     do {
         if (!hash_func_isolated()) {
@@ -198,9 +199,11 @@ static void do_hash_isolated(size_t num)
             return;
         }
 
-        counts[num]++;
+        count++;
         time = ossl_time_now();
     } while (time.t < max_time.t);
+
+    counts[num] = count;
 }
 
 /*
@@ -226,6 +229,7 @@ static void do_hash_evp_shared(size_t num)
 {
     OSSL_TIME time;
     EVP_MD_CTX *mctx = EVP_MD_CTX_new();
+    size_t count = 0;
 
     if (mctx == NULL || !EVP_DigestInit_ex(mctx, evp_md, NULL)) {
         err = 1;
@@ -238,11 +242,12 @@ static void do_hash_evp_shared(size_t num)
             goto err;
         }
  
-        counts[num]++;
+        count++;
         time = ossl_time_now();
     } while (time.t < max_time.t);
 
 err:
+    counts[num] = count;
     EVP_MD_CTX_free(mctx);
 }
 

--- a/source/evp_mac.c
+++ b/source/evp_mac.c
@@ -93,6 +93,7 @@ err:
 static void do_evp_isolated(size_t num)
 {
     OSSL_TIME time;
+    size_t count = 0;
 
     do {
         if (!evp_isolated()) {
@@ -100,15 +101,18 @@ static void do_evp_isolated(size_t num)
             return;
         }
 
-        counts[num]++;
+        count++;
         time = ossl_time_now();
     } while (time.t < max_time.t);
+
+    counts[num] = count;
 }
 
 static void do_evp_shared(size_t num)
 {
     OSSL_TIME time;
     EVP_MAC *mac = NULL;
+    size_t count = 0;
     EVP_MAC_CTX *ctx = NULL;
     OSSL_PARAM params[] = {
         OSSL_PARAM_construct_utf8_string("digest", "SHA256", 0),
@@ -129,11 +133,12 @@ static void do_evp_shared(size_t num)
             goto err;
         }
 
-        counts[num]++;
+        count++;
         time = ossl_time_now();
     } while (time.t < max_time.t);
 
 err:
+    counts[num] = count;
     EVP_MAC_CTX_free(ctx);
     EVP_MAC_free(mac);
 }
@@ -173,6 +178,7 @@ err:
 static void do_deprecated_isolated(size_t num)
 {
     OSSL_TIME time;
+    size_t count = 0;
 
     do {
         if (!hmac_isolated()) {
@@ -180,15 +186,18 @@ static void do_deprecated_isolated(size_t num)
             return;
         }
 
-        counts[num]++;
+        count++;
         time = ossl_time_now();
     } while (time.t < max_time.t);
+
+    counts[num] = count;
 }
 
 static void do_deprecated_shared(size_t num)
 {
     OSSL_TIME time;
     HMAC_CTX *ctx = HMAC_CTX_new();
+    size_t count = 0;
 
     if (ctx == NULL
         || !HMAC_Init_ex(ctx, key, KEY_SIZE, EVP_sha256(), NULL))
@@ -199,10 +208,11 @@ static void do_deprecated_shared(size_t num)
             || !HMAC_Init_ex(ctx, NULL, 0, NULL, NULL))
             goto err;
 
-        counts[num]++;
+        count++;
         time = ossl_time_now();
     } while (time.t < max_time.t);
 
+    counts[num] = count;
     return;
 
 err:

--- a/source/evp_setpeer.c
+++ b/source/evp_setpeer.c
@@ -39,6 +39,7 @@ OSSL_TIME max_time;
 void do_setpeer(size_t num)
 {
     OSSL_TIME time;
+    size_t count = 0;
 
     EVP_PKEY_CTX *pkey_ctx = NULL;
 
@@ -56,17 +57,16 @@ void do_setpeer(size_t num)
         return;
     }
 
-    counts[num] = 0;
-
     do {
         if (EVP_PKEY_derive_set_peer(pkey_ctx, pkey) <= 0) {
             err = 1;
             break;
         }
-        counts[num]++;
+        count++;
         time = ossl_time_now();
     } while (time.t < max_time.t);
 
+    counts[num] = count;
     EVP_PKEY_CTX_free(pkey_ctx);
 }
 
@@ -183,7 +183,7 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
-    counts = OPENSSL_malloc(sizeof(OSSL_TIME) * threadcount);
+    counts = OPENSSL_malloc(sizeof(size_t) * threadcount);
     if (counts == NULL) {
         printf("Failed to create counts array\n");
         return EXIT_FAILURE;

--- a/source/handshake.c
+++ b/source/handshake.c
@@ -69,6 +69,7 @@ static void do_handshake(size_t num)
     SSL *clientssl = NULL, *serverssl = NULL;
     int ret = 1;
     OSSL_TIME time;
+    size_t count = 0;
     SSL_CTX *lsctx = NULL;
     SSL_CTX *lcctx = NULL;
 
@@ -102,9 +103,11 @@ static void do_handshake(size_t num)
             SSL_CTX_free(lcctx);
             lsctx = lcctx = NULL;
         }
-        counts[num]++;
+        count++;
         time = ossl_time_now();
     } while (time.t < max_time.t);
+
+    counts[num] = count;
 
     if (!ret)
         err = 1;
@@ -117,6 +120,7 @@ static void do_handshake_ossl_lib_ctx_per_thread(size_t num)
     SSL *clientssl = NULL, *serverssl = NULL;
     int ret = 1;
     OSSL_TIME time;
+    size_t count = 0;
     OSSL_LIB_CTX *libctx = NULL;
     SSL_CTX *lsctx = NULL;
     SSL_CTX *lcctx = NULL;
@@ -156,9 +160,11 @@ static void do_handshake_ossl_lib_ctx_per_thread(size_t num)
             SSL_CTX_free(lcctx);
             lsctx = lcctx = NULL;
         }
-        counts[num]++;
+        count++;
         time = ossl_time_now();
     } while (time.t < max_time.t);
+
+    counts[num] = count;
 
     SSL_CTX_free(lsctx);
     SSL_CTX_free(lcctx);
@@ -174,6 +180,7 @@ static void do_handshake_ctx_pool(size_t num)
     SSL *clientssl = NULL, *serverssl = NULL;
     int ret = 1;
     OSSL_TIME time;
+    size_t count = 0;
     SSL_CTX *lsctx = NULL;
     SSL_CTX *lcctx = NULL;
     struct ctxs *ctx = NULL;
@@ -226,10 +233,12 @@ static void do_handshake_ctx_pool(size_t num)
             SSL_CTX_free(lcctx);
             lsctx = lcctx = NULL;
         }
-        counts[num]++;
+        count++;
         time = ossl_time_now();
     }
     while (time.t < max_time.t);
+
+    counts[num] = count;
 
     if (share_ctx == 1 && test_case == TC_OSSL_LIB_CTX_POOL) {
         SSL_CTX_free(lsctx);

--- a/source/newrawkey.c
+++ b/source/newrawkey.c
@@ -337,6 +337,7 @@ void do_newrawkey(size_t num)
 {
     EVP_PKEY *pkey;
     OSSL_TIME time;
+    size_t count = 0;
     const unsigned char *key_data = key_x25519;
     size_t key_len = sizeof(key_x25519);
 
@@ -362,8 +363,6 @@ void do_newrawkey(size_t num)
             break;
     }
 
-    counts[num] = 0;
-
     do {
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
         pkey = EVP_PKEY_new_raw_public_key_ex(NULL, alg_name, NULL, key_data,
@@ -379,9 +378,11 @@ void do_newrawkey(size_t num)
             err = 1;
         else
             EVP_PKEY_free(pkey);
-        counts[num]++;
+        count++;
         time = ossl_time_now();
     } while (time.t < max_time.t);
+
+    counts[num] = count;
 }
 
 int main(int argc, char *argv[])

--- a/source/pkeyread.c
+++ b/source/pkeyread.c
@@ -128,14 +128,13 @@ static void do_derread(size_t num)
     size_t keydata_sz;
     EVP_PKEY *pkey = NULL;
     OSSL_TIME time;
+    size_t count = 0;
 
     if (sample_id >= SAMPLE_ALL) {
         fprintf(stderr, "%s no sample key set for test\n", __func__);
         err = 1;
         return;
     }
-
-    counts[num] = 0;
 
     do {
         keydata = (const unsigned char *)sample_keys[sample_id][FORMAT_DER];
@@ -151,9 +150,11 @@ static void do_derread(size_t num)
 error:
         EVP_PKEY_free(pkey);
         pkey = NULL;
-        counts[num]++;
+        count++;
         time = ossl_time_now();
     } while (time.t < max_time.t);
+
+    counts[num] = count;
 }
 
 static int sample_name_to_id(const char *sample_name)

--- a/source/providerdoall.c
+++ b/source/providerdoall.c
@@ -44,8 +44,7 @@ static void do_providerdoall(size_t num)
 {
     int count;
     OSSL_TIME time;
-
-    counts[num] = 0;
+    size_t iters = 0;
 
     do {
         count = 0;
@@ -53,9 +52,11 @@ static void do_providerdoall(size_t num)
             err = 1;
             break;
         }
-        counts[num]++;
+        iters++;
         time = ossl_time_now();
     } while (time.t < max_time.t);
+
+    counts[num] = iters;
 }
 
 int main(int argc, char *argv[])

--- a/source/randbytes.c
+++ b/source/randbytes.c
@@ -36,15 +36,16 @@ void do_randbytes(size_t num)
 {
     unsigned char buf[32];
     OSSL_TIME time;
-
-    counts[num] = 0;
+    size_t count = 0;
 
     do {
         if (!RAND_bytes(buf, sizeof(buf)))
             err = 1;
-        counts[num]++;
+        count++;
         time = ossl_time_now();
     } while (time.t < max_time.t);
+
+    counts[num] = count;
 }
 
 int main(int argc, char *argv[])

--- a/source/rsasign.c
+++ b/source/rsasign.c
@@ -54,8 +54,7 @@ void do_rsasign(size_t num)
     EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new(rsakey, NULL);
     size_t siglen = sizeof(sig);
     OSSL_TIME time;
-
-    counts[num] = 0;
+    size_t count = 0;
 
     do {
         if (EVP_PKEY_sign_init(ctx) <= 0
@@ -64,10 +63,11 @@ void do_rsasign(size_t num)
             err = 1;
             break;
         }
-        counts[num]++;
+        count++;
         time = ossl_time_now();
     } while(time.t < max_time.t);
 
+    counts[num] = count;
     EVP_PKEY_CTX_free(ctx);
 }
 

--- a/source/sslnew.c
+++ b/source/sslnew.c
@@ -37,8 +37,7 @@ void do_sslnew(size_t num)
     SSL *s;
     BIO *rbio, *wbio;
     OSSL_TIME time;
-
-    counts[num] = 0;
+    size_t count = 0;
 
     do {
         s = SSL_new(ctx);
@@ -55,9 +54,11 @@ void do_sslnew(size_t num)
         }
 
         SSL_free(s);
-        counts[num]++;
+        count++;
         time = ossl_time_now();
     } while (time.t < max_time.t);
+
+    counts[num] = count;
 }
 
 int main(int argc, char *argv[])

--- a/source/writeread.c
+++ b/source/writeread.c
@@ -44,6 +44,7 @@ static void do_writeread(size_t num)
     int ret = 1;
     OSSL_TIME time;
     char *sbuf, *cbuf;
+    size_t count = 0;
 
     /* Prepare client and server buffers. */
     sbuf = OPENSSL_malloc(buf_size);
@@ -92,10 +93,11 @@ static void do_writeread(size_t num)
             err = 1;
             return;
         }
-        counts[num]++;
+        count++;
         time = ossl_time_now();
     } while (time.t < max_time.t);
 
+    counts[num] = count;
     perflib_shutdown_ssl_connection(serverssl, clientssl);
     if (share_ctx == 0) {
         SSL_CTX_free(lsctx);

--- a/source/x509storeissuer.c
+++ b/source/x509storeissuer.c
@@ -38,14 +38,13 @@ static void do_x509storeissuer(size_t num)
     X509_STORE_CTX *ctx = X509_STORE_CTX_new();
     X509 *issuer = NULL;
     OSSL_TIME time;
+    size_t count = 0;
 
     if (ctx == NULL || !X509_STORE_CTX_init(ctx, store, x509, NULL)) {
         printf("Failed to initialise X509_STORE_CTX\n");
         err = 1;
         goto err;
     }
-
-    counts[num] = 0;
 
     do {
         /*
@@ -60,11 +59,12 @@ static void do_x509storeissuer(size_t num)
             goto err;
         }
         issuer = NULL;
-        counts[num]++;
+        count++;
         time = ossl_time_now();
     } while (time.t < max_time.t);
 
  err:
+    counts[num] = count;
     X509_STORE_CTX_free(ctx);
 }
 


### PR DESCRIPTION
Every multi-threaded benchmark counts iterations with `counts[num]++` on a plain `size_t` array. The counters are logically private, but 8 threads × 8 bytes = one 64-byte cache line, so every thread invalidates the line for all the others on every iteration. For short-op benchmarks (evp_cipher shared mode ≈ 100 ns/op) this line ping-pong dominates the measured result.

Worse, the damage depends on where malloc (16-byte aligned) happens to place the array relative to a line boundary:

```
all 8 in one line:   |c0 c1 c2 c3 c4 c5 c6 c7|          8 threads contend  → 0.30 µs
split 6+2:        |.. c0 c1 c2 c3 c4 c5|c6 c7 ..|       mixed              → 0.20 µs
split 4+4:        |.... c0 c1 c2 c3|c4 c5 c6 c7 ....|   two groups of 4    → 0.15 µs
```

On Windows the heap randomizes placement per process start, so the same binary hops between these levels from run to run. On Linux placement is deterministic, so results are flat — until an unrelated change shifts the startup allocation sequence and re-rolls the layout: we watched a master commit "regress" `evp_cipher evp_shared` by exactly 2.0x on every Linux worker overnight, with no real performance change.

The fix: workers accumulate their count in a local variable and store it to the shared array once, when the thread finishes — the pattern `pkeyread` and the `evp_kdf`/`evp_pkey`/`evp_rand` benchmarks already use — applied to the remaining 14 benchmarks:

```
before:  every iteration:  counts[num]++         all threads write one shared line
after:   every iteration:  count++               thread-local, stays in a register
         at thread end:    counts[num] = count   one write per thread
```

Also fixes `evp_setpeer.c`'s counter allocation, which used `sizeof(OSSL_TIME)` for a `size_t` array.

A/B evidence — same host, same hour, interleaved runs, `evp_cipher -t -o evp_shared -a AES-256-CBC 8`, pinned to 8 CPUs:

<img width="1145" height="513" alt="pr-win11-ab" src="https://github.com/user-attachments/assets/03c13310-990a-4ff9-9d75-adbee41a868f" />

<img width="1259" height="477" alt="pr-debian-ab" src="https://github.com/user-attachments/assets/afbfcdaa-cffd-4788-85c4-76400fb96f28" />

The effect grows with thread count: at ≥16 threads the counters span several lines, but each line still carries up to 8 writers and the lines now bounce between L3/CCD domains. µs/op, 5 runs each on the same hosts:

| threads | Debian unpatched | Debian patched | Win11 unpatched | Win11 patched |
|---|---|---|---|---|
| 8 | 0.295 | 0.088 | 0.15–0.30 (lottery) | 0.130 |
| 16 | 0.294 | 0.087 | 0.32–0.42 | 0.13–0.15 |
| 32 | 0.325–0.370 | 0.089 | | |
| 64 | 0.417 | 0.130 | | |

The unpatched binary was measuring the counter cache line, not the cipher: patched, the per-op cost is flat from 8 to 32 threads (0.090 µs) — the apparent degradation to 0.42 µs and the run-to-run scatter were entirely the artifact. Note for consumers tracking results over time: short-op benchmark levels step down when this lands.